### PR TITLE
Bind Medicaid shortcut rules to the same person

### DIFF
--- a/accessnyc/rules/S2R029.drl
+++ b/accessnyc/rules/S2R029.drl
@@ -11,8 +11,10 @@ rule "S2R029 pregnant, medicaid or disability medicaid"
     dialect "mvel"
     
     when 
-        (Person( pregnant == true ))
-        (Person(benefitsMedicaid == true) or Person(benefitsMedicaidDisability == true))
+        Person(
+            pregnant == true,
+            benefitsMedicaid == true || benefitsMedicaidDisability == true
+        )
     then
         $programcode = new EligibleProgram()
         $programcode.setCode("S2R029")

--- a/accessnyc/rules/S2R037.drl
+++ b/accessnyc/rules/S2R037.drl
@@ -11,9 +11,9 @@ rule "s2_r037 disabled/blind, 65+, medicaid or disability medicaid"
     dialect "mvel"
     
     when 
-        (
-            (Person(disabled == true) or Person(blind == true) or Person(age >= 65)) and
-            (Person(benefitsMedicaid == true) or Person(benefitsMedicaidDisability == true))
+        Person(
+            disabled == true || blind == true || age >= 65,
+            benefitsMedicaid == true || benefitsMedicaidDisability == true
         )
     then
         $programcode = new EligibleProgram()

--- a/tests/test_same_person_medicaid_bindings.py
+++ b/tests/test_same_person_medicaid_bindings.py
@@ -1,0 +1,53 @@
+import os
+import re
+import unittest
+from pathlib import Path
+
+
+RULES_ROOT = Path(os.environ.get("RULES_ROOT", Path(__file__).resolve().parents[1]))
+
+
+def rule_block(path, name):
+    text = (RULES_ROOT / path).read_text()
+    match = re.search(rf'rule "{re.escape(name)}".*?\nend', text, re.DOTALL)
+    if match is None:
+        raise AssertionError(f"Could not find rule {name!r} in {path}")
+    return match.group(0)
+
+
+def person_patterns(block):
+    return re.findall(r"Person\((.*?)\)", block, re.DOTALL)
+
+
+class TestSamePersonMedicaidBindings(unittest.TestCase):
+    def test_nfp_binds_pregnancy_and_medicaid_to_same_person(self):
+        patterns = person_patterns(
+            rule_block(
+                "accessnyc/rules/S2R029.drl",
+                "S2R029 pregnant, medicaid or disability medicaid",
+            )
+        )
+
+        self.assertEqual(len(patterns), 1)
+        self.assertIn("pregnant == true", patterns[0])
+        self.assertIn("benefitsMedicaid == true", patterns[0])
+        self.assertIn("benefitsMedicaidDisability == true", patterns[0])
+
+    def test_home_care_binds_age_or_disability_and_medicaid_to_same_person(self):
+        patterns = person_patterns(
+            rule_block(
+                "accessnyc/rules/S2R037.drl",
+                "s2_r037 disabled/blind, 65+, medicaid or disability medicaid",
+            )
+        )
+
+        self.assertEqual(len(patterns), 1)
+        self.assertIn("disabled == true", patterns[0])
+        self.assertIn("blind == true", patterns[0])
+        self.assertIn("age >= 65", patterns[0])
+        self.assertIn("benefitsMedicaid == true", patterns[0])
+        self.assertIn("benefitsMedicaidDisability == true", patterns[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Updates the NFP Medicaid shortcut rule so pregnancy and Medicaid/disability Medicaid must be true on the same `Person` fact.
- Updates the Home Care Services Medicaid shortcut rule so disability/blindness/age and Medicaid/disability Medicaid must be true on the same `Person` fact.
- Adds regression tests that assert these rules have a single bound `Person(...)` pattern containing both sides of the eligibility condition.

Fixes #16.
Fixes #17.

## Live repros
Using the production ACCESS NYC eligibility screener endpoint at https://access.nyc.gov/eligibility/ (`action=drools` to `wp-admin/admin-ajax.php`):

- `S2R037`: disabled-only high-income adult returns false; Medicaid-only high-income adult returns false; combining those as two different people returns true.
- `S2R029`: pregnant-only high-income adult returns false; Medicaid-only high-income adult returns false; combining those as two different people returns true.

## Validation
- `python3 -m unittest discover -s tests` passes on this branch.
- `RULES_ROOT=/tmp/access-nyc-rules-same-person-parent python3 -m unittest discover -s tests` fails 2/2 against `origin/main`, confirming the tests catch the current cross-person pattern.
- `git diff --check`
- `mvn -f META-INF/maven/accessnyc/accessnyc-rules/pom.xml test` was attempted but not run because `mvn` is not installed in this environment.
